### PR TITLE
Week7 Event를 사용한 기능 분리

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/delivery/listener/DeliverListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/delivery/listener/DeliverListener.java
@@ -1,0 +1,35 @@
+package com.loopers.application.delivery.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DeliverListener {
+
+    @EventListener
+    @Async
+    public void orderDelivery(DeliveryEvent.OrderResultEvent event) {
+        log.info("order delivery event: {}", event);
+        //주문 정보를 받아서 외부 데이터 플랫폼에 보낸다.
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @EventListener
+    @Async
+    public void paymentDelivery(DeliveryEvent.PaymentResultEvent event) {
+        log.info("payment delivery event: {}", event);
+        //결제 정보를 받아서 외부 데이터 플랫폼에 보낸다.
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/delivery/listener/DeliveryEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/delivery/listener/DeliveryEvent.java
@@ -1,0 +1,59 @@
+package com.loopers.application.delivery.listener;
+
+
+import com.loopers.domain.order.Address;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderStatus;
+import com.loopers.domain.payment.PayType;
+import com.loopers.domain.payment.PaymentStatus;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class DeliveryEvent {
+    @Getter
+    public static class OrderResultEvent {
+        private Long userUid;
+
+        private Address address;
+
+        private OrderStatus orderStatus;
+
+        private BigDecimal amount;
+
+        private Long couponUid;
+
+        private List<OrderItem> items;
+
+        private OrderResultEvent(Long userUid, Address address, OrderStatus orderStatus, BigDecimal amount, Long couponUid, List<OrderItem> items) {
+            this.userUid = userUid;
+            this.address = address;
+            this.orderStatus = orderStatus;
+            this.amount = amount;
+            this.couponUid = couponUid;
+            this.items = items;
+        }
+        public static OrderResultEvent of(Long userUid, Address address, OrderStatus orderStatus, BigDecimal amount, Long couponUid, List<OrderItem> items) {
+            return new OrderResultEvent(userUid, address, orderStatus, amount, couponUid, items);
+        }
+    }
+    @Getter
+    public static class PaymentResultEvent {
+        private Long orderUid;
+        private PayType payType;
+        private PaymentStatus paymentStatus;
+        private String transactionKey;
+
+        private PaymentResultEvent(Long orderUid, PayType payType, PaymentStatus paymentStatus, String transactionKey) {
+            this.orderUid = orderUid;
+            this.payType = payType;
+            this.paymentStatus = paymentStatus;
+            this.transactionKey = transactionKey;
+        }
+        public static PaymentResultEvent of(Long orderUid, PayType payType, PaymentStatus paymentStatus, String transactionKey) {
+            return new PaymentResultEvent(orderUid, payType, paymentStatus, transactionKey);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/issue/listener/CouponIssueEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/issue/listener/CouponIssueEvent.java
@@ -1,0 +1,19 @@
+package com.loopers.application.issue.listener;
+
+import lombok.Getter;
+import lombok.ToString;
+
+public class CouponIssueEvent {
+    @Getter
+    @ToString
+    public static class UseCouponIssueEvent {
+        Long couponIssueId;
+
+        public UseCouponIssueEvent(Long couponIssueId) {
+            this.couponIssueId = couponIssueId;
+        }
+        public static UseCouponIssueEvent of(Long couponIssueId) {
+            return new UseCouponIssueEvent(couponIssueId);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/issue/listener/CouponIssueListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/issue/listener/CouponIssueListener.java
@@ -1,0 +1,31 @@
+package com.loopers.application.issue.listener;
+
+import com.loopers.domain.issue.CouponIssue;
+import com.loopers.domain.issue.CouponIssueService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponIssueListener {
+    private final CouponIssueService couponIssueService;
+
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleUseCouponIssue(CouponIssueEvent.UseCouponIssueEvent event) {
+        log.info("handleUseCouponIssue {}", event);
+        CouponIssue couponIssue = couponIssueService
+                .findById(event.couponIssueId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다."));
+        couponIssue.use();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -66,7 +66,7 @@ public class OrderCommand {
             }
 
         }
-        enum Payment{
+        public enum Payment{
             POINT,CARD
         }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,12 +1,13 @@
 package com.loopers.application.order;
 
+import com.loopers.application.issue.listener.CouponIssueEvent;
+import com.loopers.application.payment.PaymentProcessorFactory;
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.issue.CouponIssue;
 import com.loopers.domain.issue.CouponIssueService;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderService;
-import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserModel;
@@ -14,6 +15,7 @@ import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,48 +31,18 @@ import java.util.stream.Collectors;
 public class OrderFacade {
 
     private final UserService userService;
-    private final ProductService productService;
-
     private final OrderService orderService;
-    private final CouponIssueService couponIssueService;
-    private final CouponService couponService;
-
     private final PaymentProcessorFactory paymentProcessorFactory;
+    private final OrderProcessor orderProcessor;
 
-    @Transactional
     public OrderInfo.OrderResponse order(OrderCommand.Order order) {
         // 유저 확인
         UserModel user = userService.getUser(order.getUserId());
         if (user == null) {
             throw new CoreException(ErrorType.NOT_FOUND, "회원을 찾을 수 없습니다.");
         }
-        // product uid 추출
-        List<OrderCommand.Order.OrderItem> items = order.getItems();
-        Set<Long> productUidList = items.stream().map(OrderCommand.Order.OrderItem::getProductId).collect(Collectors.toSet());
-
-        //product 조회
-        List<Product> productList = productService.getProductsByProductUidsForUpdate(productUidList);
-        productService.checkProductConsistency(productUidList.size(), productList.size());
-
-        Coupon coupon = null;
-        Optional<CouponIssue> couponIssue;
-        Long couponId = 0L;
-        if (order.getCouponId() != null) {
-            couponIssue = Optional.ofNullable(couponIssueService.findByIdAndUseFlagForUpdate(order.getCouponId())
-                    .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다.")));
-            coupon = couponService.getCoupon(couponIssue.get().getCouponUid());
-            couponId = couponIssue.get().getId();
-            couponIssue.ifPresent(CouponIssue::use);
-        }
-        //totalAmount 계산
-        BigDecimal totalAmount = orderService.calulateTotalAmount(items, productList, coupon);
-
-        //order 생성
-        OrderModel orderModel = orderService
-                .create(user.getId(), order.getItems(), totalAmount, order.getPhone(), order.getReceiverName(), order.getAddress(), couponId);
-
-        // 재고 차감
-        productService.deductQuantity(items, productList);
+        // 주문 진행
+        OrderModel orderModel = orderProcessor.orderProcess(order, user);
 
         // 결제 진행
         paymentProcessorFactory.getPaymentProcessor(order).process(orderModel, order, user);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderProcessor.java
@@ -1,0 +1,67 @@
+package com.loopers.application.order;
+
+import com.loopers.application.issue.listener.CouponIssueEvent;
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.issue.CouponIssue;
+import com.loopers.domain.issue.CouponIssueService;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.UserModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProcessor {
+    private final CouponIssueService couponIssueService;
+    private final CouponService couponService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final OrderService orderService;
+    private final ProductService productService;
+
+    @Transactional
+    public OrderModel orderProcess(OrderCommand.Order order, UserModel user) {
+        // product uid 추출
+        List<OrderCommand.Order.OrderItem> items = order.getItems();
+        Set<Long> productUidList = items.stream().map(OrderCommand.Order.OrderItem::getProductId).collect(Collectors.toSet());
+
+        //product 조회
+        List<Product> productList = productService.getProductsByProductUidsForUpdate(productUidList);
+        productService.checkProductConsistency(productUidList.size(), productList.size());
+
+        Coupon coupon = null;
+        Optional<CouponIssue> couponIssue;
+        Long couponId = 0L;
+        if (order.getCouponId() != null) {
+            couponIssue = Optional.ofNullable(couponIssueService.findByIdAndUseFlagForUpdate(order.getCouponId())
+                    .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다.")));
+            coupon = couponService.getCoupon(couponIssue.get().getCouponUid());
+            couponId = couponIssue.get().getId();
+            applicationEventPublisher.publishEvent(CouponIssueEvent.UseCouponIssueEvent.of(couponId));
+        }
+        //totalAmount 계산
+        BigDecimal totalAmount = orderService.calulateTotalAmount(items, productList, coupon);
+
+        //order 생성
+        OrderModel orderModel = orderService
+                .create(user.getId(), order.getItems(), totalAmount, order.getPhone(), order.getReceiverName(), order.getAddress(), couponId);
+
+        // 재고 차감
+        productService.deductQuantity(items, productList);
+        return orderModel;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/listener/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/listener/OrderEvent.java
@@ -1,0 +1,20 @@
+package com.loopers.application.order.listener;
+
+import lombok.Getter;
+import lombok.ToString;
+
+public class OrderEvent {
+    @Getter
+    @ToString
+    public static class StatusUpdateEvent {
+        private Long id;
+        private String status;
+        private StatusUpdateEvent(Long id, String status) {
+            this.id = id;
+            this.status = status;
+        }
+        public static StatusUpdateEvent create(Long id, String status) {
+            return new StatusUpdateEvent(id, status);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/listener/OrderListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/listener/OrderListener.java
@@ -1,0 +1,61 @@
+package com.loopers.application.order.listener;
+
+import com.loopers.application.delivery.listener.DeliveryEvent;
+import com.loopers.domain.issue.CouponIssue;
+import com.loopers.domain.issue.CouponIssueService;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderListener {
+    private final OrderService orderService;
+    private final ProductService productService;
+    private final CouponIssueService couponIssueService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void orderUpdate(OrderEvent.StatusUpdateEvent event) {
+        log.info("Order update event: {}", event);
+        OrderModel order = orderService.getOrder(event.getId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 하는 주문 정보가 없습니다."));
+        if("SUCCESS".equals(event.getStatus())){
+            success(order);
+        }else {
+            fail(order);
+        }
+
+    }
+    private void fail(OrderModel order) {
+        log.info("Order fail event: {}", order);
+        order.getItems().forEach(item -> productService.getProductInfo(item.getProductUid())
+                .ifPresent(product -> product.restoreStock(item.getQuantity())));
+        order.changeStatusToFailed();
+        if(order.getCouponUid() != null) {
+            Optional<CouponIssue> couponIssue = couponIssueService.findById(order.getCouponUid());
+            couponIssue.ifPresent(CouponIssue::revoke);
+        }
+        eventPublisher.publishEvent(DeliveryEvent.OrderResultEvent
+                .of(order.getUserUid(), order.getAddress(), order.getOrderStatus(),
+                        order.getAmount(), order.getCouponUid(), order.getItems()));
+    }
+    private void success(OrderModel order) {
+        log.info("Order success event: {}", order);
+        order.changeStatusToPaid();
+        eventPublisher.publishEvent(DeliveryEvent.OrderResultEvent
+                .of(order.getUserUid(), order.getAddress(), order.getOrderStatus(),
+                        order.getAmount(), order.getCouponUid(), order.getItems()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/CardProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/CardProcessor.java
@@ -1,5 +1,6 @@
-package com.loopers.application.order;
+package com.loopers.application.payment;
 
+import com.loopers.application.order.OrderCommand;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.payment.PayType;
 import com.loopers.domain.payment.Payment;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/FailProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/FailProcessor.java
@@ -1,10 +1,12 @@
 package com.loopers.application.payment;
 
-import com.loopers.domain.order.OrderModel;
+import com.loopers.application.delivery.listener.DeliveryEvent;
+import com.loopers.application.order.listener.OrderEvent;
 import com.loopers.domain.payment.Payment;
 import com.loopers.domain.product.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,15 +15,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class FailProcessor implements PaymentUpdateProcessor{
     private final ProductService productService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     @Override
-    public void process(OrderModel order, Payment payment) {
+    public void process(Payment payment) {
         log.info("Processing fail payment {}", payment);
-        order.getItems().forEach(item -> productService.getProductInfo(item.getProductUid())
-                .ifPresent(product -> product.restoreStock(item.getQuantity())));
-        order.changeStatusToFailed();
         payment.fail();
+        applicationEventPublisher.publishEvent(DeliveryEvent.PaymentResultEvent
+                .of(payment.getOrderUid(), payment.getPayType(), payment.getPaymentStatus(), payment.getTransactionKey()));
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.payment;
 
+import com.loopers.application.order.listener.OrderEvent;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.payment.Payment;
@@ -7,6 +8,7 @@ import com.loopers.domain.payment.PaymentService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,16 +18,17 @@ public class PaymentFacade {
     private final OrderService orderService;
     private final PaymentService paymentService;
     private final PaymentStrategyFactory paymentStrategyFactory;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void updatePayment(PaymentCommand.PaymentStatusUpdate command) {
-        OrderModel orderModel = orderService.getOrder(Long.valueOf(command.getOrderId()))
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 하는 주문 정보가 없습니다."));
 
         Payment payment = paymentService.getPayment(command.getTransactionKey())
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 하는 결제 정보가 없습니다."));;
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 하는 결제 정보가 없습니다."));
+        eventPublisher.publishEvent(OrderEvent.StatusUpdateEvent.create(Long.valueOf(command.getOrderId()), command.getStatus()));
 
-        paymentStrategyFactory.getUpdateProcessor(command.getStatus()).process(orderModel, payment);
+        paymentStrategyFactory.getUpdateProcessor(command.getStatus()).process(payment);
+
 
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,5 +1,6 @@
-package com.loopers.application.order;
+package com.loopers.application.payment;
 
+import com.loopers.application.order.OrderCommand;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.user.UserModel;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorFactory.java
@@ -1,5 +1,6 @@
-package com.loopers.application.order;
+package com.loopers.application.payment;
 
+import com.loopers.application.order.OrderCommand;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUpdateProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUpdateProcessor.java
@@ -1,10 +1,9 @@
 package com.loopers.application.payment;
 
-import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.payment.Payment;
 
 public interface PaymentUpdateProcessor {
-    void process(OrderModel order, Payment payment);
+    void process(Payment payment);
 
     boolean check(String status);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PointProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PointProcessor.java
@@ -1,5 +1,7 @@
-package com.loopers.application.order;
+package com.loopers.application.payment;
 
+import com.loopers.application.order.OrderCommand;
+import com.loopers.application.order.listener.OrderEvent;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.payment.PayType;
 import com.loopers.domain.payment.Payment;
@@ -10,6 +12,7 @@ import com.loopers.domain.user.UserModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,23 +22,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointProcessor implements PaymentProcessor {
     private final PointService pointService;
     private final PaymentService paymentService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = CoreException.class)
+    @Transactional(noRollbackFor = CoreException.class)
     public void process(OrderModel orderModel, OrderCommand.Order order, UserModel user) {
         Payment payment = paymentService.createPayment(orderModel.getId(), PayType.POINT);
         //point 조회
         PointModel pointModel = pointService.getPointInfoForUpdate(user.getId())
                 .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "포인트 정보가 잘못되었습니다."));
-        payment.success();
-        orderModel.changeStatusToPaid();
-        // point 차감
         try {
+            // point 차감
             pointModel.deduct(orderModel.getAmount());
+            payment.success();
+            eventPublisher.publishEvent(OrderEvent.StatusUpdateEvent.create(orderModel.getId(), "SUCCESS"));
         }catch (CoreException e) {
-                payment.fail();
-                orderModel.changeStatusToCanceled();
-                throw e;
+            payment.fail();
+            eventPublisher.publishEvent(OrderEvent.StatusUpdateEvent.create(orderModel.getId(), "FAILED"));
+            throw e;
         }
 
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/SuccessProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/SuccessProcessor.java
@@ -1,9 +1,10 @@
 package com.loopers.application.payment;
 
-import com.loopers.domain.order.OrderModel;
+import com.loopers.application.delivery.listener.DeliveryEvent;
 import com.loopers.domain.payment.Payment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,13 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class SuccessProcessor implements PaymentUpdateProcessor {
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     @Override
-    public void process(OrderModel order, Payment payment) {
+    public void process(Payment payment) {
         log.info("Processing payment {}", payment);
-        order.changeStatusToPaid();
         payment.success();
+        applicationEventPublisher.publishEvent(DeliveryEvent.PaymentResultEvent
+                .of(payment.getOrderUid(), payment.getPayType(), payment.getPaymentStatus(), payment.getTransactionKey()));
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/scheduler/PaymentSyncScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/scheduler/PaymentSyncScheduler.java
@@ -54,7 +54,7 @@ public class PaymentSyncScheduler {
                 if (orderModel.isEmpty()) {
                     continue;
                 }
-                paymentStrategyFactory.getUpdateProcessor(pgPayment.getData().getStatus()).process(orderModel.get(), payment);
+                paymentStrategyFactory.getUpdateProcessor(pgPayment.getData().getStatus()).process(payment);
             } catch (Exception e) {
                 log.error(e.getMessage(), e);
             }
@@ -80,7 +80,7 @@ public class PaymentSyncScheduler {
             if (orderModel.isEmpty()) {
                 continue;
             }
-            paymentStrategyFactory.getUpdateProcessor("FAILED").process(orderModel.get(), payment);
+            paymentStrategyFactory.getUpdateProcessor("FAILED").process(payment);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/productLike/listener/ProductLikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/productLike/listener/ProductLikeEvent.java
@@ -1,0 +1,32 @@
+package com.loopers.application.productLike.listener;
+
+import lombok.Getter;
+import lombok.ToString;
+
+
+public class ProductLikeEvent {
+    @Getter
+    @ToString
+    public static class LikeIncrementEvent {
+        private Long productId;
+        private Long brandId;
+        private LikeIncrementEvent(Long id, Long brandId) {
+            this.productId = id;
+            this.brandId = brandId;
+        }
+        public static LikeIncrementEvent of(Long id, Long brandId) {
+            return new LikeIncrementEvent(id, brandId);
+        }
+    }
+    @Getter
+    public static class LikeDecrementEvent {
+        private Long productId;
+        private LikeDecrementEvent(Long id) {
+            this.productId = id;
+        }
+        public static LikeDecrementEvent of(Long id) {
+            return new LikeDecrementEvent(id);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/productLike/listener/ProductLikeListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/productLike/listener/ProductLikeListener.java
@@ -1,0 +1,41 @@
+package com.loopers.application.productLike.listener;
+
+import com.loopers.domain.productlike.ProductLike;
+import com.loopers.domain.productlike.ProductLikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+
+public class ProductLikeListener {
+    private final ProductLikeService productLikeService;
+
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void productLikeIncrement(ProductLikeEvent.LikeIncrementEvent event) {
+        log.info("Product like increment event: {}", event);
+        Optional<ProductLike> productLikeForUpdate = productLikeService.getProductLikeForUpdate(event.getProductId());
+        productLikeForUpdate.ifPresent(ProductLike::increment);
+        log.info("product like increment{}", productLikeForUpdate.get().getLikeCount());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void productLikeDecrement(ProductLikeEvent.LikeDecrementEvent event) {
+        log.info("Product like decrement event: {}", event);
+        Optional<ProductLike> productLikeForUpdate = productLikeService.getProductLike(event.getProductId());
+        productLikeForUpdate.ifPresent(ProductLike::decrement);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssue.java
@@ -42,4 +42,7 @@ public class CouponIssue extends BaseEntity {
         }
         useFlag = 1;
     }
+    public void revoke(){
+        useFlag = 0;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssueRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssueRepository.java
@@ -8,4 +8,6 @@ public interface CouponIssueRepository {
     List<CouponIssue> findByUserUidAndUseFlag(int UserFlag, Long userUid);
 
     Optional<CouponIssue> findByIdAndUseFlagForUpdate(Long couponId, int useFlag);
+
+    Optional<CouponIssue> findByIdAndUseFlag(Long couponId, int i);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssueService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/issue/CouponIssueService.java
@@ -20,4 +20,7 @@ public class CouponIssueService {
     public Optional<CouponIssue> findByIdAndUseFlagForUpdate(Long couponId) {
         return couponIssueRepository.findByIdAndUseFlagForUpdate(couponId, 0);
     }
+    public Optional<CouponIssue> findById(Long couponId) {
+        return couponIssueRepository.findByIdAndUseFlag(couponId, 0);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeRepository.java
@@ -7,4 +7,5 @@ public interface ProductLikeRepository {
 
     ProductLike save(ProductLike productLike);
 
+    Optional<ProductLike> findByIdForUpdate(Long productUid);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeService.java
@@ -15,6 +15,10 @@ public class ProductLikeService {
         return productLikeRepository.findById(productUid);
 
     }
+
+    public Optional<ProductLike> getProductLikeForUpdate(Long productUid) {
+        return productLikeRepository.findByIdForUpdate(productUid);
+    }
     @Transactional
     public ProductLike saveProductLike(Long productUid, long likeCount, Long brandUid) {
         return productLikeRepository.save(ProductLike.of(productUid, likeCount, brandUid));

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/issue/CouponIssueJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/issue/CouponIssueJpaRepository.java
@@ -18,4 +18,6 @@ public interface CouponIssueJpaRepository extends JpaRepository<CouponIssue, Lon
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM CouponIssue c WHERE c.id = :id AND c.useFlag = :useFlag")
     Optional<CouponIssue> findByIdAndUseFlagForUpdate(@Param("id") Long id, @Param("useFlag") int useFlag);
+
+    Optional<CouponIssue> findByIdAndUseFlag(Long couponId, int i);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/issue/CouponIssueRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/issue/CouponIssueRepositoryImpl.java
@@ -23,4 +23,9 @@ public class CouponIssueRepositoryImpl implements CouponIssueRepository {
     public Optional<CouponIssue> findByIdAndUseFlagForUpdate(Long couponId, int useFlag) {
         return couponIssueJpaRepository.findByIdAndUseFlagForUpdate(couponId, useFlag);
     }
+
+    @Override
+    public Optional<CouponIssue> findByIdAndUseFlag(Long couponId, int i) {
+        return couponIssueJpaRepository.findByIdAndUseFlag(couponId, i);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productlike/ProductLikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productlike/ProductLikeJpaRepository.java
@@ -5,8 +5,12 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ProductLikeJpaRepository extends JpaRepository<ProductLike, Long> {
+    @Query(value = "SELECT pl FROM ProductLike pl WHERE pl.productId = :productUid")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ProductLike> findByIdForUpdate(@Param("productUid") Long productUid);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/productlike/ProductLikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/productlike/ProductLikeRepositoryImpl.java
@@ -22,4 +22,9 @@ public class ProductLikeRepositoryImpl implements ProductLikeRepository {
         return productLikeJpaRepository.save(productLike);
     }
 
+    @Override
+    public Optional<ProductLike> findByIdForUpdate(Long productUid) {
+        return productLikeJpaRepository.findByIdForUpdate(productUid);
+    }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/OrderFacadeIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.loopers.application;
 
+import com.loopers.application.issue.listener.CouponIssueEvent;
+import com.loopers.application.issue.listener.CouponIssueListener;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.OrderInfo;
@@ -23,10 +25,16 @@ import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -38,7 +46,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @SpringBootTest
+@RecordApplicationEvents
 public class OrderFacadeIntegrationTest {
+
+    @MockitoSpyBean
+    private CouponIssueListener couponIssueListener;
 
     @Autowired
     private OrderFacade orderFacade;
@@ -69,6 +81,35 @@ public class OrderFacadeIntegrationTest {
     @DisplayName("주문 요청을 할 때")
     @Nested
     class Order {
+        @DisplayName("쿠폰이 이벤트가 제대로 실행되었는지 확인한다.")
+        @Test
+        void couponUseEvent_shouldBeHandledSuccessfully(){
+
+                UserModel saveUser = userJpaRepository.save(UserModel.CreateUser("testId314", "test@test.com", Gender.MALE.name(), "2025-07-13"));
+                PointModel pointModel = PointModel.create(saveUser.getId(), BigDecimal.valueOf(10000));
+                pointJpaRepository.save(pointModel);
+                Coupon savedCoupon = couponJpaRepository.save(Coupon.create(CouponType.FIXED, BigDecimal.valueOf(1000)));
+
+                CouponIssue couponIssue = customerCouponIssueJpaRepository.save(CouponIssue.of(saveUser.getId(), savedCoupon.getId()));
+                customerCouponIssueJpaRepository.saveAndFlush(couponIssue);
+                Product product1 = productJpaRepository.save(Product.create(9999L, "상의", 1000, 5));  // name: 상의
+                Product product2 = productJpaRepository.save(Product.create(9999L, "하의", 500, 5));  // name: 하의
+                Product product3 = productJpaRepository.save(Product.create(9999L, "신발", 100, 5));   // name: 신발
+
+                List<OrderCommand.Order.OrderItem> orderItemList = new ArrayList<>();
+                orderItemList.add(OrderCommand.Order.OrderItem.of(product1.getId(), 2));
+                orderItemList.add(OrderCommand.Order.OrderItem.of(product2.getId(), 2));
+                orderItemList.add(OrderCommand.Order.OrderItem.of(product3.getId(), 2));
+                OrderCommand.Order order = OrderCommand.Order.of(orderItemList, saveUser.getUserId(), "주소", "01000000000", "홍길동", savedCoupon.getId());
+
+                orderFacade.order(order);
+            // then
+            verify(couponIssueListener, times(1))
+                    .handleUseCouponIssue(any(CouponIssueEvent.UseCouponIssueEvent.class));
+
+        }
+
+
         @DisplayName("등록되지 않은 유저면 NotFound를 반환한다.")
         @Test
         void throwsNotFound_whenUserNotFound() {
@@ -176,7 +217,7 @@ public class OrderFacadeIntegrationTest {
 
             assertThat(orderModel).isPresent();
             assertThat(orderModel.get().getAmount().doubleValue()).isEqualTo(3200);
-            assertThat(orderModel.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
+            assertThat(orderModel.get().getOrderStatus()).isEqualTo(OrderStatus.CREATED);
 
         }
         @DisplayName("쿠폰이 없는 쿠폰이면 주문 요청에 실패한다.")


### PR DESCRIPTION
## 📌 Summary
- 쿠폰 사용 이벤트 처리 
- 좋아요 집계 이벤트 처리 
- 주문 및 결제 결과 상태 반영 이벤트 처리
- 주문/결제 결과 데이터플랫폼 전송 이벤트 처리
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points
(1) 쿠폰 사용시 쿠폰의 사용이 실패한다면 주문 자체가 되면 안된다고 생각하여 before_commit을 걸게 되었습니다.

(2) 기존에 주문과 결제의 transaction이 하나로 되어 있어서 이번 주차를 진행하면서 나누게 되었습니다만 제가 올바르게 나눴는지는 잘 감이 안옵니다.

(3) 예전 요구사항에 좋아요를 요청하면 그에 맞게 좋아요수를 카운팅 되어야하는 요구사항이 있었어서 동시에 요청했을 때를 생각해서 ProductLikeListener쪽에 락을 걸게 되었습니다. 원래의 저의 생각이라면 이벤트의 동시성을 무시하고 배치를 돌려서 카운트를 맞출 생각을 했을 것 같은데 멘토님의 생각이 궁금합니다.

(4) 주문 정보과 결제 정보들을 외부 데이터플랫폼에 전송할때 이벤트를 발행하는 시점은 어차피 상태 변경이 끝난 뒤이니까 @EventListener와 @Async를 조합하였는데요 굳이 after_commit으로 상태가 완료된걸 보장한 후에 해야할까요?

(5) 이벤트 기반으로 유저의 행동 에 대해 서버 레벨에서 로깅을 한다에 대해서 고민해 보았을때는 수집하고 싶은 api에 aop를 통해서 event를 발행하거나 수동으로 발행하고 이를 수집하는 listener를 만드는 방법밖에 생각이 나질 않습니다. 더 좋은 방법이 있을까요? 아니면 제가 지문 내용의 이해를 잘못한걸까요?
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

## ✅ Checklist
### 🧾 주문 ↔ 결제

- [x]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [x]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [x]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다.

### ❤️ 좋아요 ↔ 집계

- [x]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [x]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통

- [x]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
    
    > *상품 조회, 클릭, 좋아요, 주문 등*
    > 
- [x]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->